### PR TITLE
some on-this-page examples

### DIFF
--- a/docs/modules/BAPP0054776/pages/index.adoc
+++ b/docs/modules/BAPP0054776/pages/index.adoc
@@ -1,3 +1,7 @@
 =  Sales Svc
+:page-toctitle: No longer Contents
+:page-toclevels: 3
 
 This is the '*_service_*' responsible to all the Sales related tasks, handling cache for the following:
+
+include::ROOT:partial$section-levels.adoc[]

--- a/docs/modules/BAPP0054884/pages/index.adoc
+++ b/docs/modules/BAPP0054884/pages/index.adoc
@@ -1,8 +1,10 @@
 =  Booking Svc
 
-This is the '*_service_*' responsible to all the Booking flow, handling 
+This is the '*_service_*' responsible to all the Booking flow, handling
 cart items, making the reservation, make a payment, hold staterooms, handling insurance, building
 the confirmation page, updating the guest information for reservation, handling ground transfer
 offers, update dining availability, handling DVIC account, etc.
 
 It supports *_Guest_* and *_TA_* paths.
+
+include::ROOT:partial$section-levels.adoc[]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,4 +1,5 @@
 = Preface
+:page-toclevels: 0
 
 == Conventions
 The text presents some conventions to emphasize content or draw attention.
@@ -81,3 +82,5 @@ Finally, this text shows what a quote looks like:
 
 "In the end, it's not the years in your life that count. It's the life in your years."
 -- Abraham Lincoln
+
+include::ROOT:partial$section-levels.adoc[]

--- a/docs/modules/ROOT/partials/section-levels.adoc
+++ b/docs/modules/ROOT/partials/section-levels.adoc
@@ -1,0 +1,23 @@
+== Lets demonstrate section levels. This is level 1
+
+To see how this is configured:
+
+page-toctitle: {page-toctitle}
+
+page-toclevels: {page-toclevels}
+
+=== We need several to show what might be visible the the 'on this page'
+
+Paragraph?
+
+==== The max levels is 3 with the default UI, so this one should sometimes show.
+
+Paragraph.
+
+===== This is level 4, so this one should never show.
+
+Paragraph#
+
+====== This is level 5, so this one should never show.
+
+Paragraph!


### PR DESCRIPTION
Here are a few examples of configuring the on-this-page functionality.  I had to add some sections so there was something to show.  You can also set the attributes in the playbook or in the component descriptor, but I thought that would obscure the comparison with default behavior.